### PR TITLE
Add all-day events, jump-to-today, event editing and ICS escaping

### DIFF
--- a/lib/components.dart
+++ b/lib/components.dart
@@ -254,7 +254,9 @@ class _ViewSwitcherState extends State<ViewSwitcher> {
 class EventCard extends StatefulWidget {
   final CalendarEvent event;
   final VoidCallback onDelete;
-  const EventCard({super.key, required this.event, required this.onDelete});
+  final VoidCallback? onEdit;
+  const EventCard(
+      {super.key, required this.event, required this.onDelete, this.onEdit});
 
   @override
   State<EventCard> createState() => _EventCardState();
@@ -315,7 +317,9 @@ class _EventCardState extends State<EventCard> {
                                     fontWeight: FontWeight.w600, fontSize: 16)),
                             const SizedBox(height: 4),
                             Text(
-                              '${fmtTime.format(widget.event.startTime)} - ${fmtTime.format(widget.event.endTime)}',
+                              widget.event.allDay
+                                  ? 'All day'
+                                  : '${fmtTime.format(widget.event.startTime)} - ${fmtTime.format(widget.event.endTime)}',
                               style: TextStyle(
                                   color: theme.colorScheme.onSurfaceVariant,
                                   fontSize: 13),
@@ -374,16 +378,27 @@ class _EventCardState extends State<EventCard> {
                               ],
                             ),
                           ),
-                        Align(
-                          alignment: Alignment.centerRight,
-                          child: TextButton.icon(
-                            onPressed: widget.onDelete,
-                            icon: Icon(Icons.delete_outline,
-                                size: 18, color: theme.colorScheme.error),
-                            label: Text('Delete',
-                                style:
-                                    TextStyle(color: theme.colorScheme.error)),
-                          ),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            if (widget.onEdit != null)
+                              TextButton.icon(
+                                onPressed: widget.onEdit,
+                                icon: Icon(Icons.edit_outlined,
+                                    size: 18, color: theme.colorScheme.primary),
+                                label: Text('Edit',
+                                    style: TextStyle(
+                                        color: theme.colorScheme.primary)),
+                              ),
+                            TextButton.icon(
+                              onPressed: widget.onDelete,
+                              icon: Icon(Icons.delete_outline,
+                                  size: 18, color: theme.colorScheme.error),
+                              label: Text('Delete',
+                                  style: TextStyle(
+                                      color: theme.colorScheme.error)),
+                            ),
+                          ],
                         ),
                       ],
                     ),

--- a/lib/dialogs.dart
+++ b/lib/dialogs.dart
@@ -176,12 +176,16 @@ class AddEventDialog extends StatefulWidget {
   final DateTime initialSelectedDate;
   final String Function(String input) fnv1aHex;
   final Function(DateTime, CalendarEvent) onSave;
+  final CalendarEvent? existing; // non-null = edit mode
+  final Function(CalendarEvent oldEvent, CalendarEvent newEvent)? onUpdate;
 
   const AddEventDialog({
     super.key,
     required this.initialSelectedDate,
     required this.fnv1aHex,
     required this.onSave,
+    this.existing,
+    this.onUpdate,
   });
 
   @override
@@ -206,15 +210,34 @@ class _AddEventDialogState extends State<AddEventDialog> {
   late TimeOfDay startTime;
   late DateTime endDate;
   late TimeOfDay endTime;
+  bool isAllDay = false;
 
   @override
   void initState() {
     super.initState();
     final now = DateTime.now();
-    final base = widget.initialSelectedDate;
-    
-    DateTime start = DateTime(base.year, base.month, base.day, now.hour, 0);
-    DateTime end = start.add(const Duration(hours: 1));
+    final existing = widget.existing;
+
+    final DateTime start;
+    final DateTime end;
+    if (existing != null) {
+      titleController.text = existing.title;
+      locationController.text = existing.location ?? '';
+      descriptionController.text = existing.description ?? '';
+      isAllDay = existing.allDay;
+      if (existing.rrule != null && existing.rrule!.isNotEmpty) {
+        final m = RegExp(r'FREQ=([A-Z]+)').firstMatch(existing.rrule!);
+        if (m != null && freqOptions.containsKey(m.group(1))) {
+          selectedFreq = m.group(1);
+        }
+      }
+      start = existing.startTime;
+      end = existing.endTime;
+    } else {
+      final base = widget.initialSelectedDate;
+      start = DateTime(base.year, base.month, base.day, now.hour, 0);
+      end = start.add(const Duration(hours: 1));
+    }
 
     startDate = DateTime(start.year, start.month, start.day);
     startTime = TimeOfDay(hour: start.hour, minute: start.minute);
@@ -254,26 +277,39 @@ class _AddEventDialogState extends State<AddEventDialog> {
       firstDate: DateTime(2020),
       lastDate: DateTime(2040),
     );
-    if (pickedDate != null) {
-      final initialTime = isStart ? startTime : endTime;
-      final pickedTime =
-          await showTimePicker(context: context, initialTime: initialTime);
-      if (pickedTime != null) {
-        setState(() {
-          if (isStart) {
-            startDate = pickedDate;
-            startTime = pickedTime;
-          } else {
-            endDate = pickedDate;
-            endTime = pickedTime;
-          }
-        });
-      }
+    if (pickedDate == null) return;
+
+    if (isAllDay) {
+      setState(() {
+        if (isStart) {
+          startDate = pickedDate;
+        } else {
+          endDate = pickedDate;
+        }
+      });
+      return;
+    }
+
+    if (!context.mounted) return;
+    final initialTime = isStart ? startTime : endTime;
+    final pickedTime =
+        await showTimePicker(context: context, initialTime: initialTime);
+    if (pickedTime != null) {
+      setState(() {
+        if (isStart) {
+          startDate = pickedDate;
+          startTime = pickedTime;
+        } else {
+          endDate = pickedDate;
+          endTime = pickedTime;
+        }
+      });
     }
   }
 
   Widget _buildDateTimeSelector(BuildContext context, String label,
-      DateTime date, TimeOfDay time, VoidCallback onTap) {
+      DateTime date, TimeOfDay time, VoidCallback onTap,
+      {bool allDay = false}) {
     final theme = Theme.of(context);
     return InkWell(
       onTap: onTap,
@@ -291,8 +327,9 @@ class _AddEventDialogState extends State<AddEventDialog> {
             Row(
               children: [
                 Text(fmtGridDay.format(date)),
-                const SizedBox(width: 8),
-                Container(
+                if (!allDay) const SizedBox(width: 8),
+                if (!allDay)
+                  Container(
                   padding:
                       const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
                   decoration: BoxDecoration(
@@ -332,7 +369,8 @@ class _AddEventDialogState extends State<AddEventDialog> {
     );
 
     return AlertDialog(
-      title: const Text('New Event', textAlign: TextAlign.center),
+      title: Text(widget.existing != null ? 'Edit Event' : 'New Event',
+          textAlign: TextAlign.center),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
 
       // CONTENT BOX
@@ -395,20 +433,29 @@ class _AddEventDialogState extends State<AddEventDialog> {
                 ],
               ),
 
-              const SizedBox(height: 20),
+              const SizedBox(height: 8),
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('All day', style: TextStyle(fontSize: 14)),
+                value: isAllDay,
+                onChanged: (v) => setState(() => isAllDay = v),
+              ),
+              const SizedBox(height: 8),
               // ROW: STARTS + ENDS
               Row(
                 children: [
                   Expanded(
                     child: _buildDateTimeSelector(
                         context, 'Starts', startDate, startTime,
-                        () => pickDateTime(true)),
+                        () => pickDateTime(true),
+                        allDay: isAllDay),
                   ),
                   const SizedBox(width: 16),
                   Expanded(
                     child: _buildDateTimeSelector(
                         context, 'Ends', endDate, endTime,
-                        () => pickDateTime(false)),
+                        () => pickDateTime(false),
+                        allDay: isAllDay),
                   ),
                 ],
               ),
@@ -434,10 +481,19 @@ class _AddEventDialogState extends State<AddEventDialog> {
         FilledButton(
           onPressed: () {
             if (titleController.text.isEmpty) return;
-            final s = DateTime(startDate.year, startDate.month, startDate.day,
-                startTime.hour, startTime.minute);
-            final e = DateTime(endDate.year, endDate.month, endDate.day,
-                endTime.hour, endTime.minute);
+            final DateTime s;
+            final DateTime e;
+            if (isAllDay) {
+              s = DateTime(startDate.year, startDate.month, startDate.day);
+              e = DateTime(endDate.year, endDate.month, endDate.day);
+              if (e.isBefore(s)) return;
+            } else {
+              s = DateTime(startDate.year, startDate.month, startDate.day,
+                  startTime.hour, startTime.minute);
+              e = DateTime(endDate.year, endDate.month, endDate.day,
+                  endTime.hour, endTime.minute);
+              if (!e.isAfter(s)) return;
+            }
 
             String? rrule;
             if (selectedFreq != null && selectedFreq != 'NONE') {
@@ -445,7 +501,7 @@ class _AddEventDialogState extends State<AddEventDialog> {
             }
 
             final sig =
-                'manual|${titleController.text}|${s.toIso8601String()}|${e.toIso8601String()}|$rrule';
+                'manual|${titleController.text}|${s.toIso8601String()}|${e.toIso8601String()}|$rrule|$isAllDay';
             // Use the passed function for stable hash
             final id = 'man_${widget.fnv1aHex(sig)}';
 
@@ -459,9 +515,14 @@ class _AddEventDialogState extends State<AddEventDialog> {
               source: EventSource.manual,
               sourceId: 'manual',
               rrule: rrule,
+              allDay: isAllDay,
             );
 
-            widget.onSave(s, newEvent);
+            if (widget.existing != null && widget.onUpdate != null) {
+              widget.onUpdate!(widget.existing!, newEvent);
+            } else {
+              widget.onSave(s, newEvent);
+            }
             Navigator.pop(context);
           },
           child: const Text('Save'),

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -867,7 +867,7 @@ class _CalendarHomeState extends State<CalendarHome> {
     );
   }
 
-  Future<void> _showAddEventDialog() async {
+  Future<void> _showAddEventDialog({CalendarEvent? existing}) async {
     await showDialog(
       context: context,
       builder: (context) {
@@ -877,11 +877,35 @@ class _CalendarHomeState extends State<CalendarHome> {
               initialSelectedDate: _selectedDate,
               fnv1aHex: _fnv1aHex,
               onSave: _addEvent,
+              existing: existing,
+              onUpdate: _updateManualEvent,
             );
           },
         );
       },
     );
+  }
+
+  // Edit a non-recurring manual event: remove the old instance, add the new one.
+  Future<void> _updateManualEvent(
+      CalendarEvent oldEvent, CalendarEvent newEvent) async {
+    final oldDate = DateTime(oldEvent.startTime.year, oldEvent.startTime.month,
+        oldEvent.startTime.day);
+    final newDate = DateTime(newEvent.startTime.year, newEvent.startTime.month,
+        newEvent.startTime.day);
+
+    _manualEvents[oldDate]?.removeWhere((e) => e.id == oldEvent.id);
+    if (_manualEvents[oldDate]?.isEmpty ?? false) {
+      _manualEvents.remove(oldDate);
+    }
+    _manualEvents.putIfAbsent(newDate, () => []).add(newEvent);
+
+    setState(() {
+      _events = _mergeEventMaps(
+          _mergeEventMaps(_manualEvents, _importedEvents), _khalEvents);
+    });
+
+    _saveManualEventsToDisk();
   }
 
   Future<void> _addEvent(DateTime date, CalendarEvent event) async {
@@ -1139,12 +1163,18 @@ class _CalendarHomeState extends State<CalendarHome> {
 
         buffer.writeln('BEGIN:VEVENT');
         buffer.writeln('UID:${event.id}'); // Save stable ID
-        buffer.writeln('SUMMARY:${event.title}');
-        buffer.writeln('DTSTART:${fmtIcsTime.format(event.startTime)}');
-        buffer.writeln('DTEND:${fmtIcsTime.format(event.endTime)}');
-        if (event.location != null) buffer.writeln('LOCATION:${event.location}');
+        buffer.writeln('SUMMARY:${icsEscape(event.title)}');
+        if (event.allDay) {
+          buffer.writeln('DTSTART;VALUE=DATE:${fmtIcsDate.format(event.startTime)}');
+          buffer.writeln('DTEND;VALUE=DATE:${fmtIcsDate.format(event.endTime)}');
+        } else {
+          buffer.writeln('DTSTART:${fmtIcsTime.format(event.startTime)}');
+          buffer.writeln('DTEND:${fmtIcsTime.format(event.endTime)}');
+        }
+        if (event.location != null)
+          buffer.writeln('LOCATION:${icsEscape(event.location!)}');
         if (event.description != null)
-          buffer.writeln('DESCRIPTION:${event.description}');
+          buffer.writeln('DESCRIPTION:${icsEscape(event.description!)}');
         if (event.rrule != null)
           buffer.writeln('RRULE:${event.rrule}'); // Save Rule
           // Exception Dates
@@ -1254,7 +1284,8 @@ class _CalendarHomeState extends State<CalendarHome> {
     String? currentDescription;
     String? currentUid;
     String? rrule;
-    
+    bool currentAllDay = false;
+
     List<DateTime> currentExDates = []; //
     bool inEvent = false;
 
@@ -1275,9 +1306,10 @@ class _CalendarHomeState extends State<CalendarHome> {
         currentDescription = null;
         currentUid = null;
         rrule = null;
-        
+        currentAllDay = false;
+
         // RESET IT FOR EVERY NEW EVENT
-        currentExDates = []; 
+        currentExDates = [];
         
       } else if (line == 'END:VEVENT' && inEvent) {
         if (currentSummary != null && currentStart != null) {
@@ -1312,6 +1344,7 @@ class _CalendarHomeState extends State<CalendarHome> {
             isGenerated: false,
             exceptionDates: currentExDates,
             isHidden: isMasterExcluded, // MARK HIDDEN IF EXCLUDED
+            allDay: currentAllDay,
           );
 
           if (!baseEvent.startTime.isBefore(localMin) &&
@@ -1332,18 +1365,16 @@ class _CalendarHomeState extends State<CalendarHome> {
           final value = line.substring(colonIndex + 1);
 
           if (keyPart.startsWith('SUMMARY'))
-            currentSummary = value;
-          else if (keyPart.startsWith('DTSTART'))
+            currentSummary = icsUnescape(value);
+          else if (keyPart.startsWith('DTSTART')) {
             currentStart = _parseStrictDate(value);
-          else if (keyPart.startsWith('DTEND'))
+            currentAllDay = isDateOnly(value);
+          } else if (keyPart.startsWith('DTEND'))
             currentEnd = _parseStrictDate(value);
           else if (keyPart.startsWith('LOCATION'))
-            currentLocation = value;
+            currentLocation = icsUnescape(value);
           else if (keyPart.startsWith('DESCRIPTION')) {
-            currentDescription = value
-                .replaceAll('\\n', '\n')
-                .replaceAll('\\,', ',')
-                .replaceAll('\\;', ';');
+            currentDescription = icsUnescape(value);
           } else if (keyPart.startsWith('UID')) {
             currentUid = value;
           } else if (keyPart.startsWith('RRULE')) {
@@ -1562,6 +1593,7 @@ class _CalendarHomeState extends State<CalendarHome> {
               sourceId: original.sourceId,
               rrule: original.rrule,
               isGenerated: true,
+              allDay: original.allDay,
             ),
           );
         }
@@ -1753,6 +1785,19 @@ class _CalendarHomeState extends State<CalendarHome> {
           Row(
             children: [
               IconButton(
+                tooltip: 'Today',
+                onPressed: () {
+                  final now = DateTime.now();
+                  setState(() {
+                    _focusedMonth = _viewMode == CalendarViewMode.month
+                        ? DateTime(now.year, now.month)
+                        : DateTime(now.year, now.month, now.day);
+                    _selectedDate = DateTime(now.year, now.month, now.day);
+                  });
+                },
+                icon: const Icon(Icons.today_outlined),
+              ),
+              IconButton(
                 onPressed: () {
                   setState(() {
                     if (_viewMode == CalendarViewMode.month) {
@@ -1942,6 +1987,11 @@ class _CalendarHomeState extends State<CalendarHome> {
                     event: events[index],
                     onDelete: () =>
                         _deleteEvent(_selectedDate, events[index]),
+                    onEdit: (events[index].source == EventSource.manual &&
+                            (events[index].rrule == null ||
+                                events[index].rrule!.isEmpty))
+                        ? () => _showAddEventDialog(existing: events[index])
+                        : null,
                   ),
                 ),
         ),

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -33,6 +33,7 @@ class CalendarEvent {
   final bool isGenerated; // True if this is a repeat instance
   final List<DateTime> exceptionDates; // List of dates to skip
   final bool isHidden; // Hides event in a reccuring event (instead of deleting)
+  final bool allDay; // True for date-only events (no time component)
 
   const CalendarEvent({
     required this.id,
@@ -47,6 +48,7 @@ class CalendarEvent {
     this.isGenerated = false,
     this.exceptionDates = const [],
     this.isHidden = false, // DEFAULT FALSE
+    this.allDay = false,
   });
 
   Map<String, dynamic> toJson() => {
@@ -57,6 +59,7 @@ class CalendarEvent {
         'location': location,
         'description': description,
         'rrule': rrule,
+        'allDay': allDay,
       };
 
   factory CalendarEvent.fromJson(Map<String, dynamic> json, String sourceId) {
@@ -70,9 +73,10 @@ class CalendarEvent {
       source: EventSource.imported,
       sourceId: sourceId,
       rrule: json['rrule'],
+      allDay: json['allDay'] == true,
     );
   }
-  
+
   // Helper copyWith
   CalendarEvent copyWith({
     String? id,
@@ -87,6 +91,7 @@ class CalendarEvent {
     bool? isGenerated,
     List<DateTime>? exceptionDates,
     bool? isHidden,
+    bool? allDay,
   }) {
     return CalendarEvent(
       id: id ?? this.id,
@@ -101,6 +106,7 @@ class CalendarEvent {
       isGenerated: isGenerated ?? this.isGenerated,
       exceptionDates: exceptionDates ?? this.exceptionDates,
       isHidden: isHidden ?? this.isHidden,
+      allDay: allDay ?? this.allDay,
     );
   }
 }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -11,4 +11,47 @@ final DateFormat fmtDayNum = DateFormat('d');
 final DateFormat fmtDayName = DateFormat('EEE');
 final DateFormat fmtTime = DateFormat('h:mm a');
 final DateFormat fmtIcsTime = DateFormat('yyyyMMdd\'T\'HHmm00');
+final DateFormat fmtIcsDate = DateFormat('yyyyMMdd');
 final DateFormat fmtGridDay = DateFormat('MMM d');
+
+// RFC 5545 TEXT escaping. Backslash must be escaped first on the way out.
+String icsEscape(String input) {
+  return input
+      .replaceAll('\\', '\\\\')
+      .replaceAll('\n', '\\n')
+      .replaceAll(',', '\\,')
+      .replaceAll(';', '\\;');
+}
+
+String icsUnescape(String input) {
+  final out = StringBuffer();
+  for (var i = 0; i < input.length; i++) {
+    final ch = input[i];
+    if (ch == '\\' && i + 1 < input.length) {
+      final next = input[i + 1];
+      switch (next) {
+        case 'n':
+        case 'N':
+          out.write('\n');
+        case '\\':
+          out.write('\\');
+        case ',':
+          out.write(',');
+        case ';':
+          out.write(';');
+        default:
+          out.write(next);
+      }
+      i++;
+    } else {
+      out.write(ch);
+    }
+  }
+  return out.toString();
+}
+
+// A DTSTART/DTEND value with no time component (yyyymmdd) is an all-day date.
+bool isDateOnly(String value) {
+  final v = value.trim();
+  return !v.contains('T') && v.length == 8;
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,34 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+// Unit tests for the ICS text helpers and all-day date detection added for
+// escaping, all-day events, and import round-trips. Hard assertions on values.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:google_calendar_app/main.dart';
+import 'package:ever_cal/utils.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  group('ICS text escaping', () {
+    test('round-trips commas, semicolons, newlines and backslashes', () {
+      const raw = 'Lunch, then meeting; line1\nline2 path C:\\tmp';
+      expect(icsUnescape(icsEscape(raw)), raw);
+    });
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    test('escapes a newline as literal \\n (no real line break in output)', () {
+      expect(icsEscape('a\nb'), 'a\\nb');
+      expect(icsEscape('a\nb').contains('\n'), isFalse);
+    });
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    test('unescape keeps an escaped backslash before n as two chars', () {
+      expect(icsUnescape('a\\\\nb'), 'a\\nb');
+    });
+  });
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  group('isDateOnly', () {
+    test('true for a date-only value', () {
+      expect(isDateOnly('20260101'), isTrue);
+    });
+
+    test('false for a date-time value', () {
+      expect(isDateOnly('20260101T090000'), isFalse);
+    });
   });
 }


### PR DESCRIPTION
Targets the current `main` (the multi-file rewrite). I checked what the rewrite already has and only added what was missing.

Already in `main`, so not touched: recurrence (including `YEARLY`, `BYDAY`, `EXDATE`), theme persistence via `settings.json`, and delete-single-occurrence.

## New
- **All-day events.** Added an `allDay` field to `CalendarEvent`. The parser detects a date-only `DTSTART`, the writer emits `DTSTART;VALUE=DATE`, the add/edit dialog has an `All day` toggle, and cards show `All day` instead of a time range.
- **Edit events.** Non-recurring manual events get an Edit button that reopens the dialog prefilled. Recurring, imported and khal events are left as-is (editing those safely needs more design around the master/exception model).
- **Jump to today** button in the header (works in both month and week view).

## Fix
`_saveManualEventsToDisk` wrote `SUMMARY`/`LOCATION`/`DESCRIPTION` raw. A multi-line description (the dialog allows 3 lines) wrote a real line break that the reader dropped on reload, losing everything after the first line. `,` `;` `\` were also unsafe. Added RFC 5545 text escaping on write and unescaping on read (`SUMMARY`/`LOCATION` are now unescaped too, which helps imported calendars).

## Tests
`test/widget_test.dart` was the placeholder template referencing a non-existent package and class, so it did not compile. Replaced it with unit tests for the ICS escape round-trip and date-only detection.

## Verification
- `flutter analyze`: no new errors or warnings.
- `flutter test`: passes.
- `flutter build linux --debug`: builds, launched and rendered on a Wayland session (today button visible).
- The ICS logic is unit-tested. The dialog interactions (edit, all-day toggle) are build and render verified, not click-tested.

## Notes
- All-day events use inclusive `DTEND` dates for internal round-trip simplicity.
- Pre-existing analyzer warnings in the rewrite (unused imports/fields, `_sameEvent`) are left untouched to keep this focused.
